### PR TITLE
Address implicit memory aliasing in a loop.

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,6 +216,8 @@ func main() {
 	hostname := getHostName(*swaggerResp)
 
 	for _, api := range paths {
+		api := api
+
 		if len(api.Params) == 0 {
 			continue
 		}


### PR DESCRIPTION
When using range, `api` is copy of the value. This is maybe the simplest way to fix the issue to get the reference to the value.